### PR TITLE
services: allow HTML links in description (SanitizedHTML)

### DIFF
--- a/invenio_checks/services/schema.py
+++ b/invenio_checks/services/schema.py
@@ -10,7 +10,7 @@
 from datetime import timezone
 
 from marshmallow import EXCLUDE, Schema, fields
-from marshmallow_utils.fields import SanitizedUnicode, TZDateTime
+from marshmallow_utils.fields import SanitizedHTML, SanitizedUnicode, TZDateTime
 from marshmallow_utils.permissions import FieldPermissionsMixin
 
 from ..models import CheckRunStatus
@@ -30,7 +30,8 @@ class CheckConfigSchema(Schema, FieldPermissionsMixin):
     updated = TZDateTime(timezone=timezone.utc, format="iso", dump_only=True)
 
     title = SanitizedUnicode(required=True)
-    description = SanitizedUnicode()
+    # Rule descriptions can contain HTML to link to a page with more details about the rule
+    description = SanitizedHTML()
 
     active = fields.Boolean(load_default=True)
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Fixes zenodo/zenodo-rdm#1135

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
