### PR TITLE
component: use datetime.now with timezone.utc

### DIFF
--- a/invenio_checks/components.py
+++ b/invenio_checks/components.py
@@ -7,7 +7,7 @@
 
 """Record service component."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask import current_app
 from invenio_db import db
@@ -71,7 +71,7 @@ class ChecksComponent(ServiceComponent):
         for check in all_checks:
             try:
                 check_cls = current_checks_registry.get(check.check_id)
-                start_time = datetime.now()
+                start_time = datetime.now(timezone.utc)
                 res = check_cls().run(record, check.params)
                 if not res.sync:
                     continue
@@ -105,7 +105,7 @@ class ChecksComponent(ServiceComponent):
                         is_draft=record.is_draft,
                         revision_id=record.revision_id,
                         start_time=start_time,
-                        end_time=datetime.now(),
+                        end_time=datetime.now(timezone.utc),
                         status=CheckRunStatus.COMPLETED,
                         state=None,
                         result=res.to_dict(),
@@ -116,7 +116,7 @@ class ChecksComponent(ServiceComponent):
                     latest_check.is_draft = record.is_draft
                     latest_check.revision_id = record.revision_id
                     latest_check.start_time = start_time
-                    latest_check.end_time = datetime.now()
+                    latest_check.end_time = datetime.now(timezone.utc)
                     latest_check.start_time = start_time
                     latest_check.result = res.to_dict()
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

We should store dates as UTC and not with the default timezone.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
