### PR TITLE
views: explanation text in checks requests tab

### DIFF
--- a/invenio_checks/templates/semantic-ui/invenio_checks/requests/details.html
+++ b/invenio_checks/templates/semantic-ui/invenio_checks/requests/details.html
@@ -17,43 +17,62 @@ under the terms of the MIT License; see LICENSE file for more details.
       <a class="item active"><i class="{% include 'invenio_checks/requests/overall_severity_level.html' %}"></i> {{ _("Metadata check") }}</a>
     </div>
   </div>
-  <div class="twelve wide column">
+  <div class="thirteen wide column">
 
     <h5 class="ui header text-muted rel-pl-2 rel-pb-1">Rules</h5>
 
-    <div class="ui very relaxed list rel-pl-2">
-    {% for check in checks %}
-      {% for rule_result in check.result.rule_results %}
-        {#
-          Get the icon class for the rule result of one rule result.
-          This code depends on 2 fields of each `rule_results` : `success` and `level`.
-          If the boolean `success` field is true, it means that the check was successful.
-          Otherwise, it means that the check failed, and we display the severity `level` of the check.
-        #}
-        {% if rule_result.success %}
-          {% set rule_severity_level = "success" %}
-        {% elif rule_result.level == "info" %}
-          {% set rule_severity_level = "warning" %}
-        {% elif rule_result.level == "error" %}
-          {% set rule_severity_level = "error" %}
-        {% else %}
-          {% set rule_severity_level = "unknown" %}
-        {% endif %}
+    <div class="ui column stackable grid">
+      <div class="ten wide column">
 
-        <div class="item">
-          <i class="{{ severity_level_icons_tpl.severity_level_icons[rule_severity_level] }}"></i>
-          <div class="content">
-            <div class="header">{{ rule_result.rule_message }}</div>
+        <div class="ui very relaxed list rel-pl-2">
+        {% for check in checks %}
+          {% for rule_result in check.result.rule_results %}
             {#
-              Rule descriptions can contain HTML to link to a page with more details about the rule.
-              This field is sanitized in the backend with SanitizedHTML.
+              Get the icon class for the rule result of one rule result.
+              This code depends on 2 fields of each `rule_results` : `success` and `level`.
+              If the boolean `success` field is true, it means that the check was successful.
+              Otherwise, it means that the check failed, and we display the severity `level` of the check.
             #}
-            <div class="pt-5 text-muted">{{ rule_result.rule_description | safe }}</div>
-          </div>
+            {% if rule_result.success %}
+              {% set rule_severity_level = "success" %}
+            {% elif rule_result.level == "info" %}
+              {% set rule_severity_level = "warning" %}
+            {% elif rule_result.level == "error" %}
+              {% set rule_severity_level = "error" %}
+            {% else %}
+              {% set rule_severity_level = "unknown" %}
+            {% endif %}
+
+            <div class="item">
+              <i class="{{ severity_level_icons_tpl.severity_level_icons[rule_severity_level] }}"></i>
+              <div class="content">
+                <div class="header">{{ rule_result.rule_message }}</div>
+                {#
+                  Rule descriptions can contain HTML to link to a page with more details about the rule.
+                  This field is sanitized in the backend with SanitizedHTML.
+                #}
+                <div class="pt-5 text-muted">{{ rule_result.rule_description | safe }}</div>
+              </div>
+            </div>
+          {% endfor %}
+        {% endfor %}
         </div>
-      {% endfor %}
-    {% endfor %}
+      </div>
+
+      <div class="six wide column">
+
+        <div class="ui info message">
+          <div class="header">What is this about?</div>
+          <p>These checks help ensure that your submission is compliant with the related open science requirements in Horizon Europe (as defined in your grant agreement). All submissions to the EU Open Research Repository (or one of the EU project communities) are subject to the checks.</p>
+          <h5 class="ui header">How do I fix warnings/errors?</h5>
+          <p>Go to the "Record" tab and click the orange "Edit" button. All errors and recommendations are displayed inline in the upload form.</p>
+          <a href="/communities/eu/pages/open-science" target="_blank"><strong>Learn more</strong></a>
+        </div>
+
+      </div>
+
     </div>
 
   </div>
+
 </div>


### PR DESCRIPTION
Fixes zenodo/zenodo-rdm#1133
Ignore whitespaces when diffing

![image](https://github.com/user-attachments/assets/01611f36-4120-4911-b749-5275d3ea58fd)
