### PR TITLE
requests-ui: handle multiple check runs of same type

### DIFF
--- a/invenio_checks/templates/semantic-ui/invenio_checks/requests/details.html
+++ b/invenio_checks/templates/semantic-ui/invenio_checks/requests/details.html
@@ -10,12 +10,12 @@ under the terms of the MIT License; see LICENSE file for more details.
 {% import "invenio_checks/requests/severity_level_icons.html" as severity_level_icons_tpl %}
 
 {% set first_check = (checks | map(attribute='config.check_cls') | sort(attribute='sort_order') | first).id %}
+{% set check_classes = checks | map(attribute="config.check_cls") | unique(attribute="id") %}
 
 <div class="ui column stackable divided grid">
   <div class="three wide column pr-0">
     <div class="ui fluid secondary vertical menu ml-0 mr-0 rdm-tab-menu">
-      {% set check_classes = checks | map(attribute='config.check_cls') %}
-      {% for check_class in check_classes|sort(attribute='sort_order') %}
+      {% for check_class in check_classes|sort(attribute="sort_order") %}
       <a class="item {% if loop.index == 1 %}active{% endif %}" data-tab="{{ check_class.id }}">
         {% set check_class_id = check_class.id %}
         <i class="{% include 'invenio_checks/requests/overall_severity_level.html' %}"></i>
@@ -24,9 +24,8 @@ under the terms of the MIT License; see LICENSE file for more details.
     </div>
   </div>
   <div class="thirteen wide column">
-    {% set check_classes = checks | map(attribute='config.check_cls') %}
-    {% for check in checks %}
-      {% set check_id = check.config.check_cls.id %}
+    {% for checks_group in checks | groupby('config.check_id') %}
+      {% set check_id = checks_group.grouper %}
       <div class="ui tab {% if check_id == first_check %}active{% endif %}" data-tab="{{check_id}}">
         {% set tab_template = 'invenio_checks/requests/' + check_id + '_tab.html' %}
         {% include tab_template %}

--- a/invenio_checks/templates/semantic-ui/invenio_checks/requests/file_formats_tab.html
+++ b/invenio_checks/templates/semantic-ui/invenio_checks/requests/file_formats_tab.html
@@ -7,6 +7,8 @@ Invenio is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.
 #}
 
+{# TODO: Handle multiple check runs of file format checks #}
+{% set check = checks | first %}
 {% set severity = check.result.errors | map(attribute='severity') | first %}
 
 <div class="ui column stackable grid">

--- a/invenio_checks/templates/semantic-ui/invenio_checks/requests/metadata_tab.html
+++ b/invenio_checks/templates/semantic-ui/invenio_checks/requests/metadata_tab.html
@@ -9,36 +9,37 @@ under the terms of the MIT License; see LICENSE file for more details.
 
 <div class="ui column stackable grid">
   <div class="ten wide column">
-
     <div class="ui very relaxed list rel-pl-2">
-      {% for rule_result in check.result.rule_results %}
-      {#
-      Get the icon class for the rule result of one rule result.
-      This code depends on 2 fields of each `rule_result` : `success` and `level`.
-      If the boolean `success` field is true, it means that the check was successful.
-      Otherwise, it means that the check failed, and we display the severity `level` of the check.
-      #}
-      {% if rule_result.success %}
-        {% set rule_severity_level = "success" %}
-      {% elif rule_result.level == "info" %}
-        {% set rule_severity_level = "warning" %}
-      {% elif rule_result.level == "error" %}
-        {% set rule_severity_level = "error" %}
-      {% else %}
-        {% set rule_severity_level = "unknown" %}
-      {% endif %}
+      {% for check in checks %}
+        {% for rule_result in check.result.rule_results %}
+        {#
+        Get the icon class for the rule result of one rule result.
+        This code depends on 2 fields of each `rule_result` : `success` and `level`.
+        If the boolean `success` field is true, it means that the check was successful.
+        Otherwise, it means that the check failed, and we display the severity `level` of the check.
+        #}
+        {% if rule_result.success %}
+          {% set rule_severity_level = "success" %}
+        {% elif rule_result.level == "info" %}
+          {% set rule_severity_level = "warning" %}
+        {% elif rule_result.level == "error" %}
+          {% set rule_severity_level = "error" %}
+        {% else %}
+          {% set rule_severity_level = "unknown" %}
+        {% endif %}
 
-      <div class="item">
-        <i class="{{ severity_level_icons_tpl.severity_level_icons[rule_severity_level] }}"></i>
-        <div class="content">
-          <div class="header">{{ rule_result.rule_message }}</div>
-          {#
-          Rule descriptions can contain HTML to link to a page with more details about the rule.
-          This field is sanitized in the backend with SanitizedHTML.
-          #}
-          <div class="pt-5 text-muted">{{ rule_result.rule_description | safe }}</div>
+        <div class="item">
+          <i class="{{ severity_level_icons_tpl.severity_level_icons[rule_severity_level] }}"></i>
+          <div class="content">
+            <div class="header">{{ rule_result.rule_message }}</div>
+            {#
+            Rule descriptions can contain HTML to link to a page with more details about the rule.
+            This field is sanitized in the backend with SanitizedHTML.
+            #}
+            <div class="pt-5 text-muted">{{ rule_result.rule_description | safe }}</div>
+          </div>
         </div>
-      </div>
+        {% endfor %}
       {% endfor %}
     </div>
   </div>


### PR DESCRIPTION
* Handles rendering of multiple check run results for the metadata
  check type.
* Uses the first instance of file format checks.
