### PR TITLE
chores: replaced importlib_xyz with importlib

### DIFF
--- a/invenio_checks/base.py
+++ b/invenio_checks/base.py
@@ -6,7 +6,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 """Check implementations and registry."""
 
-import importlib_metadata
+from invenio_base.utils import entry_points
 
 
 class Check:
@@ -65,7 +65,7 @@ class ChecksRegistry:
 
     def load_from_entry_points(self, app, ep_name):
         """Load checks from entry points."""
-        for ep in set(importlib_metadata.entry_points(group=ep_name)):
+        for ep in entry_points(group=ep_name):
             check_cls_or_func = ep.load()
             check_cls = check_cls_or_func
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages = find:
 python_requires = >=3.9
 zip_safe = False
 install_requires =
-    invenio-base>=2.0.0,<3.0.0
+    invenio-base>=2.3.0,<3.0.0
     invenio-i18n>=3.0.0,<4.0.0
     invenio-communities>=19.0.0,<20.0.0
     invenio-drafts-resources>=7.0.0,<8.0.0


### PR DESCRIPTION
### Description

Replaced `importlib_metadata` and `importlib_resources` with `importlib`.

* Using invenio_base.utils.entry_points for entry_points

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
