### PR TITLE
feat: allow empty community_id for check config

### DIFF
--- a/invenio_checks/alembic/1773672705_allow_empty_community_id.py
+++ b/invenio_checks/alembic/1773672705_allow_empty_community_id.py
@@ -1,0 +1,37 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2016-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Allow empty community id."""
+
+import sqlalchemy_utils
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "1773672705"
+down_revision = "c39b06b59667"
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    op.alter_column(
+        "checks_config",
+        "community_id",
+        existing_type=sqlalchemy_utils.types.uuid.UUIDType(),
+        nullable=True,
+    )
+
+
+def downgrade():
+    """Downgrade database."""
+    op.alter_column(
+        "checks_config",
+        "community_id",
+        existing_type=sqlalchemy_utils.types.uuid.UUIDType(),
+        nullable=False,
+    )

--- a/invenio_checks/api.py
+++ b/invenio_checks/api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2025 CERN.
-# Copyright (C) 2025 Graz University of Technology.
+# Copyright (C) 2025-2026 Graz University of Technology.
 #
 # Invenio-Checks is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 
 from flask import current_app
 from invenio_db.uow import ModelCommitOp
+from sqlalchemy import or_
 
 from .models import CheckConfig, CheckRun, CheckRunStatus
 from .proxies import current_checks_registry
@@ -29,14 +30,20 @@ class ChecksAPI:
 
     @classmethod
     def get_configs(cls, community_ids):
-        """Get all check configurations for a list of community IDs."""
-        if not community_ids:
-            return []
+        """Get all check configurations for a list of community IDs.
 
-        return CheckConfig.query.filter(
-            CheckConfig.community_id.in_(community_ids),
-            CheckConfig.enabled.is_(True),
+        Always include the global checks configs to the community checks.
+        """
+        conditions = [CheckConfig.community_id.is_(None)]
+
+        if community_ids:
+            conditions.append(CheckConfig.community_id.in_(community_ids))
+
+        all_configs = CheckConfig.query.filter(
+            CheckConfig.enabled.is_(True), or_(*conditions)
         ).all()
+
+        return all_configs
 
     @classmethod
     def run_check(cls, config, record, uow, is_draft=None):

--- a/invenio_checks/models.py
+++ b/invenio_checks/models.py
@@ -52,7 +52,7 @@ class CheckConfig(db.Model, db.Timestamp):
 
     id = db.Column(UUIDType, primary_key=True, default=uuid.uuid4)
     community_id = db.Column(
-        UUIDType, db.ForeignKey(CommunityMetadata.id), nullable=False
+        UUIDType, db.ForeignKey(CommunityMetadata.id), nullable=True
     )
     check_id = db.Column(db.String(255), nullable=False)
     params = db.Column(JSON, nullable=False)


### PR DESCRIPTION
This PR should address the need for global checks by:

- allowing null community_id value in checks_config table -> this will indicate a **global** check
- getting the check configs will always query the **global** checks before trying to search for the community defined checks

Solves the first part of this issue: https://github.com/inveniosoftware/invenio-checks/issues/47


