### PR TITLE
feat: support metadata check error paths

### DIFF
--- a/invenio_checks/contrib/metadata/check.py
+++ b/invenio_checks/contrib/metadata/check.py
@@ -109,7 +109,7 @@ class MetadataCheck(Check):
 
         output = [
             {
-                "field": check.path,
+                "field": rule_result.error_path or check.path,
                 "messages": [rule_result.rule_message],
                 "description": rule_result.rule_description,
                 "severity": rule_result.level,

--- a/invenio_checks/contrib/metadata/rules.py
+++ b/invenio_checks/contrib/metadata/rules.py
@@ -7,7 +7,7 @@
 """Metadata check rules."""
 
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 from .expressions import (
     ComparisonExpression,
@@ -30,6 +30,7 @@ class Rule:
         description=None,
         condition=None,
         checks=None,
+        error_path=None,
     ):
         """Initialize the rule."""
         self.id = id
@@ -39,6 +40,7 @@ class Rule:
         self.level = level
         self.condition = condition
         self.checks = checks or []
+        self.error_path = error_path
 
     def evaluate(self, record):
         """Evaluate the rule against a record."""
@@ -69,6 +71,7 @@ class RuleResult:
     level: str
     success: bool
     check_results: List[ExpressionResult]
+    error_path: Optional[str] = None
 
     @classmethod
     def from_rule(cls, rule, success: bool, check_results: List[ExpressionResult]):
@@ -81,6 +84,7 @@ class RuleResult:
             level=rule.level,
             success=success,
             check_results=check_results,
+            error_path=rule.error_path,
         )
 
     def to_dict(self):
@@ -142,6 +146,7 @@ class RuleParser:
         message = config.get("message", "")
         description = config.get("description", "")
         level = config.get("level", "info")
+        error_path = config.get("error_path")
 
         # Parse condition if present
         condition = None
@@ -154,4 +159,13 @@ class RuleParser:
             check = ExpressionParser.parse(check_config)
             checks.append(check)
 
-        return Rule(rule_id, title, message, level, description, condition, checks)
+        return Rule(
+            rule_id,
+            title,
+            message,
+            level,
+            description,
+            condition,
+            checks,
+            error_path,
+        )


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Closes [#725](https://github.com/CERNDocumentServer/cds-rdm/issues/725)
Related PR: [cds-rdm#749](https://github.com/CERNDocumentServer/cds-rdm/pull/749)
https://github.com/inveniosoftware/invenio-rdm-records/pull/2289

This PR adds optional error_path support to metadata check rules.

Before this change, invenio-checks always returned the checked field path as the UI error path. In the DOI case, the rule needs to validate pids.doi.identifier, but the deposit UI reads DOI errors on pids.doi, so the error was not being picked up correctly.

With this change, a rule can still validate the correct field while returning the UI error on a different field path when needed. If error_path is not provided, the existing behavior remains unchanged.





### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
