### PR TITLE
fix: don't add None community_id from global check runs to community_ids set

### DIFF
--- a/invenio_checks/components.py
+++ b/invenio_checks/components.py
@@ -54,7 +54,8 @@ class ChecksComponent(ServiceComponent):
         # Take into account configs from past check runs (could be inclusion requests)
         past_runs = ChecksAPI.get_runs(draft)
         for run in past_runs:
-            community_ids.add(str(run.config.community_id))
+            if run.config.community_id is not None:
+                community_ids.add(str(run.config.community_id))
 
         updated_runs = []
         configs = ChecksAPI.get_configs(community_ids)
@@ -74,7 +75,8 @@ class ChecksComponent(ServiceComponent):
         # from the latest published record version
         record_runs = ChecksAPI.get_runs(record)
         for run in record_runs:
-            community_ids.add(str(run.config.community_id))
+            if run.config.community_id is not None:
+                community_ids.add(str(run.config.community_id))
 
         configs = ChecksAPI.get_configs(community_ids)
         for config in configs:
@@ -91,7 +93,8 @@ class ChecksComponent(ServiceComponent):
         # getting all the involved community IDs.
         past_runs = CheckRun.query.filter_by(record_id=record.id).all()
         for run in past_runs:
-            community_ids.add(str(run.config.community_id))
+            if run.config.community_id is not None:
+                community_ids.add(str(run.config.community_id))
 
         # Run checks for all relevant communities
         configs = ChecksAPI.get_configs(community_ids)


### PR DESCRIPTION
## Problem

When a record has runs from global checks (`community_id = NULL`), collecting community IDs from those runs via `str(run.config.community_id)` produces the string `"None"`. That string ends up in the `community_ids` set and gets passed to `ChecksAPI.get_configs`, which tries to bind it as a UUID in a SQL `IN` clause. `UUIDType` then raises:

```
ValueError: bytes is not a 16-char string
```

This affects `update_draft`, `new_version`, and `edit` in `ChecksComponent`.

## Fix

Skip `None` community IDs when collecting IDs from past check runs. Global checks are already returned by the `community_id IS NULL` condition in `ChecksAPI.get_configs`, so nothing is lost.

## How to reproduce

1. Create a global check config (`community_id = NULL`).
2. Save/update a draft record — this triggers a check run.
3. Save/update the draft again — `update_draft` collects IDs from past runs, hits `"None"`, and raises the error.